### PR TITLE
Add back support for sass

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function SassCompiler(cfg) {
 SassCompiler.prototype.brunchPlugin = true;
 SassCompiler.prototype.type = 'stylesheet';
 SassCompiler.prototype.extension = 'scss';
-SassCompiler.prototype.pattern = /\.scss$/;
+SassCompiler.prototype.pattern = /\.s[ac]ss$/;
 SassCompiler.prototype._bin = isWindows ? 'sass.bat' : 'sass';
 SassCompiler.prototype._compass_bin = isWindows ? 'compass.bat' : 'compass';
 
@@ -96,7 +96,8 @@ SassCompiler.prototype._nativeCompile = function(source, callback) {
       data: source.data,
       includePaths: this._getIncludePaths(source.path),
       outputStyle: (this.optimize ? "nested" : 'compressed'),
-      sourceComments: !this.optimize
+      sourceComments: !this.optimize,
+      indentedSyntax: sassRe.test(source.path)
     },
     function(error, result) {
       if (error) {

--- a/test.js
+++ b/test.js
@@ -39,6 +39,17 @@ describe('sass-brunch plugin', function() {
     });
   });
 
+  it('should compile and produce valid result for sass', function(done) {
+    var content = '$a: 5px\n.test\n  border-radius: $a';
+    var expected = '.test {\n  border-radius: 5px; }\n';
+
+    plugin.compile(content, 'file.sass', function(error, data) {
+      expect(error).not.to.be.ok;
+      expect(data).to.equal(expected);
+      done();
+    });
+  });
+
   it('should output valid deps', function(done) {
     var content = "\
     @import \'valid1\';\n\


### PR DESCRIPTION
This fork removed support for `sass`, which proves to be an important part of the build tool. This PR adds back support for sass.